### PR TITLE
Refactor LED handling for 3 RGB LEDs

### DIFF
--- a/potatomelt/src/subsystems/led.cpp
+++ b/potatomelt/src/subsystems/led.cpp
@@ -4,7 +4,8 @@
 #include "../melty_config.h"
 
 rmt_item32_t led_data[6*8];
-uint8_t pixel_color[6]; 
+// 3 LEDs, 3 channels each (G,R,B): 3*3 = 9
+uint8_t pixel_color[9]; 
 
 LED::LED() {
     rmt_config_t rmt_cfg = RMT_DEFAULT_CONFIG_TX(NEOPIXEL_PIN, NEOPIXEL_RMT);
@@ -51,38 +52,38 @@ void LED::leds_on_gradient(int color) {
 }
 
 void LED::leds_off() {
-    pixel_color[0] = pixel_color[1] = pixel_color[2] = 0;
-    pixel_color[3] = pixel_color[4] = pixel_color[5] = 0;
+    for (int i = 0; i < 9; ++i) pixel_color[i] = 0;
     write_pixel();
 }
 
 void LED::leds_on_rgb(int red, int green, int blue) {
     // neopixels usually use GRB addressing rather than RGB
-    pixel_color[0] = pixel_color[3] = green;
-    pixel_color[1] = pixel_color[4] = red;
-    pixel_color[2] = pixel_color[5] = blue;
+    for (int i = 0; i < 3; ++i) {
+        pixel_color[i*3 + 0] = green;
+        pixel_color[i*3 + 1] = red;
+        pixel_color[i*3 + 2] = blue;
+    }
     write_pixel();
 }
 
 void LED::write_pixel() {
     int index = 0;
-    for (auto chan : pixel_color) {
-      uint8_t value = chan;
-      for (int bit = 7; bit >= 0; bit--) {
-        if ((value >> bit) & 1) {
-          led_data[index].level0 = 1;
-          led_data[index].duration0 = 8;
-          led_data[index].level1 = 0;
-          led_data[index].duration1 = 4;
-        } else {
-          led_data[index].level0 = 1;
-          led_data[index].duration0 = 4;
-          led_data[index].level1 = 0;
-          led_data[index].duration1 = 8;
+    for (int i = 0; i < 9; ++i) {
+        uint8_t value = pixel_color[i];
+        for (int bit = 7; bit >= 0; bit--) {
+            if ((value >> bit) & 1) {
+                led_data[index].level0 = 1;
+                led_data[index].duration0 = 8;
+                led_data[index].level1 = 0;
+                led_data[index].duration1 = 4;
+            } else {
+                led_data[index].level0 = 1;
+                led_data[index].duration0 = 4;
+                led_data[index].level1 = 0;
+                led_data[index].duration1 = 8;
+            }
+            index++;
         }
-        index++;
-      }
     }
-
-    rmt_write_items(NEOPIXEL_RMT, led_data, 6*8, false);
-  }
+    rmt_write_items(NEOPIXEL_RMT, led_data, 9*8, false);
+}


### PR DESCRIPTION
Updated pixel_color array to support 3 LEDs with separate RGB channels (total 9 values). Refactored related methods to use loops for setting and writing pixel data, improving scalability and maintainability.